### PR TITLE
Improve board and evaluation layout for responsive UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,25 +4,325 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chess Interface</title>
   <style>
-    .highlight-selection { box-shadow: inset 0 0 0 3px #ff0 !important; }
-    body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #ccc; margin: 0; padding: 20px; }
-    .container { background: #ccc; padding: 20px 20px 40px; border-radius: 0; /* removed border shadow */ max-width: 750px; width: 100%; text-align: center; }
-    .board-wrapper { display: inline-flex; align-items: flex-start; margin-bottom: 120px; }
-    #board { width: 400px; height: 400px; position: relative; }
-    #gauge { width: 20px; height: 400px; background: #000; margin-left: 10px; position: relative; top: 50px; /* moved down */ }
-    #gauge-white { width: 100%; background: #fff; position: absolute; bottom: 0; height: 50%; }
-    #engine-output { text-align: left; margin-top: 20px; }
-    #controls { margin-top: 10px; }
-    button { margin: 5px; padding: 8px 16px; border: none; border-radius: 5px; color: #fff; cursor: pointer; }
-    #best-move-button { background: #007bff; }
-    #piece-moves-button { background: #17a2b8; }
-    #gauge-button { background: #6610f2; }
-    #flip-button { background: #28a745; }
-    #edit-button { background: #ffc107; color: #000; }
-    button:disabled { background: #ccc; cursor: not-allowed; }
-    .highlight-move-from, .highlight-move-to { background: rgba(255,255,0,0.5) !important; }
-    #status { margin-top: 10px; font-weight: bold; }
-    .move-rating { position: absolute; bottom: 5px; right: 5px; background: rgba(0,0,0,0.7); color: #fff; font-size: 12px; padding: 2px 4px; border-radius: 3px; pointer-events: none; z-index: 5; }
+    :root {
+      color-scheme: dark;
+    }
+
+    body {
+      font-family: "Inter", "Segoe UI", sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background: radial-gradient(circle at top, #2b2f46 0%, #10121c 55%, #06070c 100%);
+      margin: 0;
+      padding: 24px;
+      color: #eef0f6;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 960px;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      align-items: stretch;
+    }
+
+    .board-wrapper {
+      display: flex;
+      align-items: stretch;
+      background: rgba(20, 20, 31, 0.94);
+      border-radius: 28px;
+      overflow: hidden;
+      box-shadow: 0 28px 60px rgba(3, 6, 16, 0.55);
+    }
+
+    .board-container {
+      flex: 1 1 auto;
+      padding: 28px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    #board {
+      width: min(72vw, 440px);
+      max-width: 440px;
+    }
+
+    .eval-sidebar {
+      width: 210px;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      padding: 28px 22px;
+      gap: 18px;
+      background: rgba(18, 18, 28, 0.96);
+      border-left: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .gauge-shell {
+      flex: 1 1 auto;
+      display: flex;
+      align-items: stretch;
+      justify-content: center;
+    }
+
+    #gauge {
+      position: relative;
+      width: 84px;
+      height: 100%;
+      min-height: 220px;
+      border-radius: 22px;
+      background: linear-gradient(180deg, #2f344b 0%, #11131d 100%);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      overflow: hidden;
+    }
+
+    #gauge::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: rgba(255, 255, 255, 0.06);
+      transform: translateX(-50%);
+    }
+
+    #gauge-white {
+      width: 100%;
+      background: linear-gradient(180deg, #f3f5ff 0%, #d2d8f7 100%);
+      position: absolute;
+      bottom: 0;
+      height: 50%;
+      transition: height 0.35s ease;
+    }
+
+    .info-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    #status {
+      margin: 0;
+      font-size: 1.02rem;
+      font-weight: 600;
+      color: #f3f6ff;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      color: #d4d9eb;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .info-row .label {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: #8b90a8;
+    }
+
+    .info-row .value {
+      font-weight: 600;
+      font-size: 0.98rem;
+      color: #f6f7ff;
+    }
+
+    #controls {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 12px;
+    }
+
+    button {
+      margin: 0;
+      padding: 10px 18px;
+      border: none;
+      border-radius: 14px;
+      color: #fff;
+      cursor: pointer;
+      background: linear-gradient(135deg, #4856ff 0%, #232d97 100%);
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+      min-width: 150px;
+    }
+
+    button:hover:not(:disabled) {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(35, 52, 158, 0.45);
+    }
+
+    button:disabled {
+      background: rgba(84, 90, 128, 0.4);
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    #piece-moves-button {
+      background: linear-gradient(135deg, #1dbfcc 0%, #136677 100%);
+    }
+
+    #gauge-button {
+      background: linear-gradient(135deg, #a144ff 0%, #5323a0 100%);
+    }
+
+    #flip-button {
+      background: linear-gradient(135deg, #34c964 0%, #127035 100%);
+    }
+
+    #edit-button {
+      background: linear-gradient(135deg, #ffd96f 0%, #e6a421 100%);
+      color: #1d1d1d;
+    }
+
+    .highlight-selection {
+      box-shadow: inset 0 0 0 3px #f2ff5f !important;
+    }
+
+    .highlight-move-from,
+    .highlight-move-to {
+      background: rgba(255, 255, 0, 0.38) !important;
+    }
+
+    .move-rating {
+      position: absolute;
+      bottom: 6px;
+      right: 6px;
+      background: rgba(9, 12, 24, 0.82);
+      color: #f6f9ff;
+      font-size: 12px;
+      padding: 3px 5px;
+      border-radius: 6px;
+      pointer-events: none;
+      z-index: 5;
+    }
+
+    .board-container .chessboard-7492f {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .board-container .board-b72b1 {
+      order: 1;
+    }
+
+    .board-container .spare-pieces-top {
+      order: 2;
+      margin-top: 10px;
+    }
+
+    .board-container .spare-pieces-bottom {
+      order: 3;
+    }
+
+    .board-container .spare-pieces-7492f {
+      display: flex;
+      justify-content: center;
+      gap: 6px;
+    }
+
+    @media (max-width: 1024px) {
+      .board-wrapper {
+        flex-direction: column;
+      }
+
+      .board-container {
+        padding-bottom: 20px;
+      }
+
+      .eval-sidebar {
+        width: 100%;
+        flex-direction: row;
+        align-items: center;
+        border-left: none;
+        border-top: 1px solid rgba(255, 255, 255, 0.06);
+        padding: 22px 24px;
+        gap: 24px;
+      }
+
+      .gauge-shell {
+        flex: 0 0 auto;
+        width: 72px;
+        height: 170px;
+      }
+
+      #gauge {
+        width: 100%;
+        height: 100%;
+        min-height: 160px;
+      }
+
+      .info-panel {
+        flex: 1 1 auto;
+      }
+    }
+
+    @media (max-width: 640px) {
+      body {
+        padding: 16px;
+      }
+
+      .container {
+        gap: 20px;
+      }
+
+      .board-container {
+        padding: 20px;
+      }
+
+      #board {
+        width: min(86vw, 420px);
+      }
+
+      button {
+        min-width: 140px;
+        padding: 10px 16px;
+        font-size: 0.92rem;
+      }
+
+      .info-row .value {
+        font-size: 0.92rem;
+      }
+    }
+
+    @media (max-width: 420px) {
+      .eval-sidebar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .gauge-shell {
+        width: 100%;
+        height: 160px;
+      }
+
+      #gauge {
+        min-height: 140px;
+      }
+
+      .info-row {
+        font-size: 0.88rem;
+      }
+
+      #status {
+        font-size: 0.94rem;
+      }
+    }
   </style>
   <script src="libs/jquery.min.js"></script>
   <link href="libs/chessboard-1.0.0.min.css" rel="stylesheet">
@@ -32,13 +332,25 @@
 <body>
   <div class="container">
     <div class="board-wrapper">
-      <div id="board"></div>
-      <div id="gauge"><div id="gauge-white"></div></div>
-    </div>
-    <p id="status"></p>
-    <div id="engine-output">
-      <p>Best Move: <span id="best-move">N/A</span></p>
-      <p>Evaluation: <span id="evaluation">N/A</span></p>
+      <div class="board-container">
+        <div id="board"></div>
+      </div>
+      <div class="eval-sidebar">
+        <div class="gauge-shell">
+          <div id="gauge"><div id="gauge-white"></div></div>
+        </div>
+        <div class="info-panel">
+          <p id="status"></p>
+          <div class="info-row">
+            <span class="label">Best Move</span>
+            <span class="value" id="best-move">N/A</span>
+          </div>
+          <div class="info-row">
+            <span class="label">Evaluation</span>
+            <span class="value" id="evaluation">N/A</span>
+          </div>
+        </div>
+      </div>
     </div>
     <div id="controls">
       <button id="best-move-button" disabled>Best Move</button>
@@ -148,6 +460,8 @@
     };
     if (board) board.destroy();
     board = Chessboard('board', cfg);
+    board.resize();
+    requestAnimationFrame(() => board && board.resize());
     boardEl.off('click.square').on('click.square', 'div.square-55d63', function() {
       const cls = $(this).attr('class').split(/\s+/);
       const sq = cls.find(c => /^square-[a-h][1-8]$/.test(c));
@@ -234,6 +548,7 @@
   $('#edit-button').on('click', () => { editMode = !editMode; if (!editMode) { moveSourceSquare = null; } $('#edit-button').text(editMode ? 'Exit Edit' : 'Edit Mode'); renderBoard(); });
 
   renderBoard(); initEngine(); updateStatus();
+  $(window).off('resize.board').on('resize.board', () => { if (board) board.resize(); });
 });
 
   </script>


### PR DESCRIPTION
## Summary
- restyle the board container and evaluation sidebar into a unified panel with responsive typography and buttons
- relocate engine status, best move, and evaluation readouts into the sidebar and ensure single-line presentation across viewports
- adjust spare piece placement in edit mode so both colors appear beneath the board and add responsive board resizing hooks

## Testing
- Manual validation in Chromium via Playwright screenshots

------
https://chatgpt.com/codex/tasks/task_e_68d8f2dc4dcc8333a499f8d7033363b7