### PR TITLE
Remove Advantage label text from evaluation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
   <div class="container">
     <div class="board-shell">
       <div class="eval-bar">
-        <span id="evaluation-label">Advantage</span>
+        <span id="evaluation-label"></span>
         <div id="gauge"><div id="gauge-white"></div></div>
       </div>
       <div class="board-container">


### PR DESCRIPTION
## Summary
- remove the hard-coded "Advantage" text from the evaluation label in the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91e595e248333801e265c3b313de4