### PR TITLE
Align board UI and normalize Stockfish turn

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,17 @@
       box-shadow: 0 28px 60px rgba(3, 6, 16, 0.55);
     }
 
-    .eval-bar {
+    .board-area {
       width: min(72vw, 440px);
       max-width: 440px;
-      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+    }
+
+    .eval-bar {
+      width: 100%;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -103,8 +110,7 @@
     }
 
     #board {
-      width: min(72vw, 440px);
-      max-width: 440px;
+      width: 100%;
     }
 
     #info-line {
@@ -245,6 +251,10 @@
     }
 
     @media (max-width: 768px) {
+      .board-area {
+        gap: 16px;
+      }
+
       .eval-bar {
         gap: 6px;
       }
@@ -259,7 +269,7 @@
         gap: 20px;
       }
 
-      #board {
+      .board-area {
         width: min(86vw, 420px);
       }
 
@@ -285,12 +295,14 @@
 <body>
   <div class="container">
     <div class="board-shell">
-      <div class="eval-bar">
-        <span id="evaluation-label"></span>
-        <div id="gauge"><div id="gauge-white"></div></div>
-      </div>
-      <div class="board-container">
-        <div id="board"></div>
+      <div class="board-area">
+        <div class="eval-bar">
+          <span id="evaluation-label"></span>
+          <div id="gauge"><div id="gauge-white"></div></div>
+        </div>
+        <div class="board-container">
+          <div id="board"></div>
+        </div>
       </div>
       <div id="info-line">
         <span id="status">Ready</span>
@@ -344,6 +356,16 @@
         const clamped = Math.max(-2000, Math.min(2000, cp));
         const pct = ((clamped + 2000) / 4000) * 100;
         $('#gauge-white').css('width', pct + '%');
+      }
+
+      function normalizeFenTurn(fen, turn) {
+        if (typeof fen !== 'string') return fen;
+        const trimmed = fen.trim();
+        if (!trimmed.length) return fen;
+        const parts = trimmed.split(/\s+/);
+        if (parts.length < 2) return trimmed;
+        parts[1] = turn === 'b' ? 'b' : 'w';
+        return parts.join(' ');
       }
 
       function updateBestMoveDisplay() {
@@ -879,9 +901,11 @@
     $('#evaluation').text('...');
     updateBestMoveDisplay();
 
+    const normalizedFen = normalizeFenTurn(latestAnalysisFen, game.turn());
+
     engine.postMessage('stop');
     engine.postMessage(`setoption name MultiPV value ${multiPv}`);
-    engine.postMessage(`position fen ${latestAnalysisFen}`);
+    engine.postMessage(`position fen ${normalizedFen}`);
     if (searchMoves && searchMoves.length) {
       engine.postMessage(`go depth ${depth} searchmoves ${searchMoves.join(' ')}`);
     } else {


### PR DESCRIPTION
## Summary
- wrap the evaluation bar and chessboard in a shared container so they stay centered together
- normalize the FEN sent to Stockfish so the engine always receives the correct side to move

## Testing
- python3 -m http.server 8000 (manually opened /index.html)


------
https://chatgpt.com/codex/tasks/task_e_68d9387c13d08333a6d5ff10ce9c9d5a