### PR TITLE
Fix evaluation display to respect side to move

### DIFF
--- a/index.html
+++ b/index.html
@@ -874,15 +874,23 @@
 
       const cpMatch = line.match(/score cp (-?\d+)/);
       const mateMatch = line.match(/score mate (-?\d+)/);
+      const turn = game.turn();
 
       if (cpMatch) {
-        const value = parseInt(cpMatch[1], 10);
+        let value = parseInt(cpMatch[1], 10);
+        if (turn === 'b') {
+          value = -value;
+        }
         const prefix = value > 0 ? '+' : '';
         $('#evaluation').text(`${prefix}${(value / 100).toFixed(2)}`);
         updateGauge(value);
       } else if (mateMatch) {
-        const mateValue = parseInt(mateMatch[1], 10);
-        $('#evaluation').text(`Mate in ${mateMatch[1]}`);
+        let mateValue = parseInt(mateMatch[1], 10);
+        if (turn === 'b') {
+          mateValue = -mateValue;
+        }
+        const matePrefix = mateValue > 0 ? '' : '-';
+        $('#evaluation').text(`Mate in ${matePrefix}${Math.abs(mateValue)}`);
         updateGauge(mateValue > 0 ? 2000 : -2000);
       }
 


### PR DESCRIPTION
## Summary
- flip centipawn scores when it is Black to move so the displayed eval is from White's perspective
- adjust mate score presentation and gauge updates to use the normalized value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94a55408483339946eac7ef6520b8