### PR TITLE
Lower replay autoplay depth and keep replay active when flipping board

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,14 +365,14 @@
       let moveHistory = [];
       let navigationIndex = 0;
       let autoPlayPending = false;
-      let autoPlayTargetDepth = 20;
+      let autoPlayTargetDepth = 12;
       let autoPlayFen = null;
       let currentBestMove = null;
       let currentDepth = 0;
       let pieceMoveRatings = new Map();
       let waitingForAutoBestMove = false;
       let autoMoveCandidate = null;
-      const DEFAULT_DEPTH = 20;
+      const DEFAULT_DEPTH = 12;
       const BACKGROUND_EVAL_DEPTH = 14;
       const DEFAULT_THREADS = 4;
       const DEFAULT_HASH_MB = 469;
@@ -1571,7 +1571,6 @@
     updateStatus();
   });
   $('#flip-button').on('click', () => {
-    if (replayMode) stopReplay();
     orientation = orientation === 'white' ? 'black' : 'white';
     renderBoard();
     updateStatus();


### PR DESCRIPTION
## Summary
- reduce the default replay/autoplay depth threshold from 20 to 12 so imported PGNs advance once depth 12 is reached
- allow flipping the board orientation without cancelling an in-progress replay

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9993917e88333adaf38513a7b9ea2