### PR TITLE
Limit replay depth after PGN import

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,6 +365,7 @@
       let moveHistory = [];
       let navigationIndex = 0;
       const DEFAULT_DEPTH = 24;
+      const PGN_REPLAY_DEPTH = 12;
       const BACKGROUND_EVAL_DEPTH = 20;
       const DEFAULT_THREADS = 4;
       const DEFAULT_HASH_MB = 469;
@@ -1736,7 +1737,7 @@
     updateStatus();
     updateNavigationButtons();
     if (lastImportWasPgn) {
-      startReplayFromIndex(0, DEFAULT_DEPTH);
+      startReplayFromIndex(0, PGN_REPLAY_DEPTH);
     } else {
       requestAnalysis({ highlight: shouldHighlightBest && bestMoveVisible, revealBest: bestMoveVisible });
     }


### PR DESCRIPTION
## Summary
- add a dedicated PGN replay depth constant
- start auto-play replays after PGN import at depth 12 to keep other analysis infinite

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0101526883339accf3c921c9fd27