### PR TITLE
Add advantage bar and improve edit mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      gap: 16px;
     }
 
     .board-container {
@@ -72,6 +73,145 @@
     #status {
       margin: 0;
       white-space: nowrap;
+      transition: color 0.2s ease;
+    }
+
+    #status.is-editing {
+      cursor: pointer;
+      color: #f8f29d;
+      text-decoration: underline;
+      text-decoration-style: dashed;
+      text-decoration-color: rgba(248, 242, 157, 0.7);
+    }
+
+    #status.is-editing:focus-visible {
+      outline: 2px solid #f8f29d;
+      outline-offset: 3px;
+    }
+
+    .advantage-bar {
+      width: 100%;
+      max-width: 440px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      color: #eef0f6;
+      background: rgba(14, 18, 32, 0.35);
+      border-radius: 16px;
+      padding: 14px 18px;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+      backdrop-filter: blur(6px);
+      transition: box-shadow 0.3s ease, background 0.3s ease;
+    }
+
+    .advantage-bar__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.76rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #cfd5fb;
+    }
+
+    .advantage-bar__status {
+      font-weight: 600;
+      font-size: 0.92rem;
+      color: #eef1ff;
+      transition: color 0.3s ease;
+    }
+
+    .advantage-bar__track {
+      position: relative;
+      --white-ratio: 50%;
+      height: 18px;
+      border-radius: 999px;
+      overflow: hidden;
+      background: linear-gradient(90deg, rgba(247, 248, 255, 0.92) 0%, rgba(247, 248, 255, 0.92) var(--white-ratio), rgba(14, 16, 28, 0.88) var(--white-ratio), rgba(14, 16, 28, 0.88) 100%);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+      transition: background 0.4s ease;
+    }
+
+    .advantage-bar__track::after {
+      content: '';
+      position: absolute;
+      top: -3px;
+      bottom: -3px;
+      width: 5px;
+      border-radius: 6px;
+      background: linear-gradient(180deg, rgba(238, 241, 255, 0.95), rgba(142, 154, 232, 0.95));
+      left: calc(var(--white-ratio) - 2.5px);
+      box-shadow: 0 0 12px rgba(86, 105, 255, 0.55);
+      transition: left 0.4s ease;
+    }
+
+    .advantage-bar__footer {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.82rem;
+      color: #d5daf4;
+    }
+
+    .advantage-bar__side {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+      font-weight: 600;
+    }
+
+    .advantage-bar__side--white .advantage-bar__percent {
+      color: #f9fbff;
+    }
+
+    .advantage-bar__side--black .advantage-bar__percent {
+      color: #cbd4ff;
+    }
+
+    .advantage-bar__side-label {
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 0.74rem;
+      color: rgba(229, 233, 255, 0.9);
+    }
+
+    .advantage-bar__percent {
+      font-variant-numeric: tabular-nums;
+    }
+
+    .advantage-bar.is-white-favored {
+      background: rgba(37, 48, 94, 0.42);
+      box-shadow: inset 0 0 0 1px rgba(120, 150, 255, 0.4), 0 12px 26px rgba(60, 88, 190, 0.25);
+    }
+
+    .advantage-bar.is-black-favored {
+      background: rgba(32, 24, 48, 0.42);
+      box-shadow: inset 0 0 0 1px rgba(180, 120, 220, 0.38), 0 12px 26px rgba(120, 60, 160, 0.24);
+    }
+
+    .advantage-bar.is-balanced {
+      background: rgba(16, 20, 32, 0.42);
+      box-shadow: inset 0 0 0 1px rgba(200, 210, 250, 0.25), 0 10px 22px rgba(32, 38, 70, 0.26);
+    }
+
+    .advantage-bar.is-loading .advantage-bar__track::after {
+      animation: advantage-bar-loading 1.1s ease-in-out infinite;
+      box-shadow: 0 0 12px rgba(116, 132, 255, 0.7);
+    }
+
+    .advantage-bar.is-loading .advantage-bar__status {
+      color: #d0d5f0;
+    }
+
+    @keyframes advantage-bar-loading {
+      0% {
+        opacity: 0.45;
+      }
+      50% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0.45;
+      }
     }
 
     .info-line-item {
@@ -241,6 +381,23 @@
         <div class="board-container">
           <div id="board"></div>
         </div>
+        <div class="advantage-bar is-balanced" id="advantage-bar" aria-live="polite" aria-busy="false">
+          <div class="advantage-bar__header">
+            <span>Advantage</span>
+            <span class="advantage-bar__status" id="advantage-status">Awaiting evaluation</span>
+          </div>
+          <div class="advantage-bar__track" id="advantage-track"></div>
+          <div class="advantage-bar__footer">
+            <span class="advantage-bar__side advantage-bar__side--white">
+              <span class="advantage-bar__side-label">White</span>
+              <span class="advantage-bar__percent" id="advantage-white-percent">50%</span>
+            </span>
+            <span class="advantage-bar__side advantage-bar__side--black">
+              <span class="advantage-bar__percent" id="advantage-black-percent">50%</span>
+              <span class="advantage-bar__side-label">Black</span>
+            </span>
+          </div>
+        </div>
       </div>
       <div id="info-line">
         <span id="status">Ready</span>
@@ -263,6 +420,11 @@
       let board, engine;
       const game = new Chess();
       const boardEl = $('#board');
+      const advantageBarElement = document.getElementById('advantage-bar');
+      const advantageTrackElement = document.getElementById('advantage-track');
+      const advantageStatusElement = document.getElementById('advantage-status');
+      const advantageWhiteElement = document.getElementById('advantage-white-percent');
+      const advantageBlackElement = document.getElementById('advantage-black-percent');
       let baseFen = game.fen();
       let selectedSquare = null;
       let moveSourceSquare = null;
@@ -300,6 +462,7 @@
       let autoPlayDepthSatisfied = false;
       const evaluationNavElement = document.getElementById('evaluation-nav');
       let evaluationTimeline = [];
+      let lastAdvantageRatio = 0.5;
       let backgroundEngine = null;
       let backgroundEngineReady = false;
       let backgroundEvaluationQueue = [];
@@ -357,6 +520,79 @@
       function capitalizeWord(word) {
         if (typeof word !== 'string' || !word.length) return '';
         return word.charAt(0).toUpperCase() + word.slice(1);
+      }
+
+      function computeAdvantageRatio(entry) {
+        if (!entry) {
+          return Math.max(0, Math.min(1, lastAdvantageRatio));
+        }
+
+        if (entry.type === 'mate') {
+          if (entry.winningSide === 'white') return 1;
+          if (entry.winningSide === 'black') return 0;
+          return 0.5;
+        }
+
+        if (entry.type === 'cp' && typeof entry.cp === 'number' && !Number.isNaN(entry.cp)) {
+          const limited = Math.max(-2000, Math.min(2000, entry.cp));
+          const ratio = 1 / (1 + Math.exp(-limited / 120));
+          return Math.max(0, Math.min(1, ratio));
+        }
+
+        if (typeof entry.value === 'number' && !Number.isNaN(entry.value)) {
+          const bounded = Math.max(-2000, Math.min(2000, entry.value));
+          return (bounded + 2000) / 4000;
+        }
+
+        return Math.max(0, Math.min(1, lastAdvantageRatio));
+      }
+
+      function updateAdvantageBar(entry, { neutral = false, message = null } = {}) {
+        if (!advantageBarElement || !advantageTrackElement) return;
+
+        let ratio = neutral ? 0.5 : Math.max(0, Math.min(1, lastAdvantageRatio));
+        let summary = message || (neutral ? 'Awaiting evaluation' : (advantageStatusElement ? advantageStatusElement.textContent || '' : ''));
+
+        if (entry) {
+          ratio = computeAdvantageRatio(entry);
+          const fallback = entry.winningSide ? `${capitalizeWord(entry.winningSide)} edge` : 'Balanced';
+          summary = entry.shortText || entry.text || fallback;
+        } else if (!entry && !message && neutral) {
+          summary = 'Awaiting evaluation';
+        }
+
+        ratio = Math.max(0, Math.min(1, ratio));
+        lastAdvantageRatio = ratio;
+
+        const whitePercent = Math.max(0, Math.min(100, Math.round(ratio * 100)));
+        const blackPercent = 100 - whitePercent;
+
+        advantageTrackElement.style.setProperty('--white-ratio', `${(ratio * 100).toFixed(2)}%`);
+        if (advantageWhiteElement) {
+          advantageWhiteElement.textContent = `${whitePercent}%`;
+        }
+        if (advantageBlackElement) {
+          advantageBlackElement.textContent = `${blackPercent}%`;
+        }
+        if (advantageStatusElement) {
+          advantageStatusElement.textContent = summary || '';
+        }
+        if (advantageBarElement) {
+          const isWhiteFavored = ratio >= 0.53;
+          const isBlackFavored = ratio <= 0.47;
+          advantageBarElement.classList.toggle('is-white-favored', isWhiteFavored);
+          advantageBarElement.classList.toggle('is-black-favored', isBlackFavored);
+          advantageBarElement.classList.toggle('is-balanced', !isWhiteFavored && !isBlackFavored);
+        }
+      }
+
+      function setAdvantageBarLoading(isLoading, { reset = true } = {}) {
+        if (!advantageBarElement) return;
+        advantageBarElement.classList.toggle('is-loading', !!isLoading);
+        advantageBarElement.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+        if (isLoading) {
+          updateAdvantageBar(null, { neutral: !!reset, message: 'Analyzing...' });
+        }
       }
 
       function describeCentipawnAdvantage(cp) {
@@ -764,18 +1000,34 @@
         const label = entry.text || 'N/A';
         $('#evaluation').text(label);
         setTimelineEntry(navigationIndex, entry);
+        setAdvantageBarLoading(false);
+        updateAdvantageBar(entry);
       }
 
       function applyStoredEvaluationIfAvailable() {
         const entry = getTimelineEntry(navigationIndex);
         if (entry && entry.text) {
           $('#evaluation').text(entry.text);
+          setAdvantageBarLoading(false);
+          updateAdvantageBar(entry);
         } else {
           $('#evaluation').text('N/A');
+          setAdvantageBarLoading(false);
+          updateAdvantageBar(null, { neutral: true, message: 'Awaiting evaluation' });
         }
       }
 
-      function syncEvalBarWidth() {}
+      function syncEvalBarWidth() {
+        if (!advantageBarElement) return;
+        const container = boardEl && typeof boardEl.closest === 'function'
+          ? boardEl.closest('.board-container')
+          : null;
+        const refEl = container && container.length ? container.get(0) : null;
+        if (!refEl) return;
+        const bounds = refEl.getBoundingClientRect();
+        if (!bounds || !bounds.width) return;
+        advantageBarElement.style.maxWidth = `${Math.round(bounds.width)}px`;
+      }
 
       function normalizeFenTurn(fen, turn) {
         if (typeof fen !== 'string') return fen;
@@ -911,6 +1163,11 @@
         }
         clearEvaluationTimeline(1);
         $('#evaluation').text('N/A');
+        currentBestMove = null;
+        latestAnalysisFen = null;
+        setAdvantageBarLoading(false);
+        updateAdvantageBar(null, { neutral: true, message: 'Awaiting evaluation' });
+        updateBestMoveDisplay();
         updateNavigationButtons();
         renderEvaluationNavigation();
       }
@@ -1016,6 +1273,19 @@
     renderBoard();
     updateStatus();
     requestAnalysis({ highlight: shouldHighlightBest && bestMoveVisible, revealBest: bestMoveVisible });
+  }
+
+  function toggleEditingTurn() {
+    if (!editMode) return;
+    const fen = game.fen();
+    if (typeof fen !== 'string' || !fen.length) return;
+    const parts = fen.trim().split(/\s+/);
+    if (parts.length < 2) return;
+    parts[1] = parts[1] === 'w' ? 'b' : 'w';
+    const updatedFen = parts.join(' ');
+    const loaded = game.load(updatedFen);
+    if (!loaded) return;
+    commitEditedBoardState();
   }
 
   function clonePiece(piece) {
@@ -1258,6 +1528,14 @@
     else if (game.in_draw()) txt = 'Game over, drawn position';
     else txt = `${turn} to move${game.in_check() ? `, ${turn} is in check` : ''}`;
     $('#status').text(txt);
+    $('#status').toggleClass('is-editing', editMode);
+    if (editMode) {
+      $('#status').attr('title', 'Click to toggle the side to move');
+      $('#status').attr('tabindex', '0');
+    } else {
+      $('#status').removeAttr('title');
+      $('#status').removeAttr('tabindex');
+    }
   }
 
   function onDragStart(src, piece) {
@@ -1549,6 +1827,7 @@
         $('#evaluation').text('...');
       }
     }
+    setAdvantageBarLoading(true, { reset: !pieceAnalysis });
     updateBestMoveDisplay();
     if (replay) {
       updateEvaluationProgressLabel();
@@ -1619,6 +1898,17 @@
   });
   $('#prev-button').on('click', goToPreviousMove);
   $('#next-button').on('click', goToNextMove);
+  $('#status').on('click', () => {
+    if (!editMode) return;
+    toggleEditingTurn();
+  });
+  $('#status').on('keydown', event => {
+    if (!editMode) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleEditingTurn();
+    }
+  });
 
   $(document).on('keydown', event => {
     const activeElement = document.activeElement;
@@ -1671,13 +1961,24 @@
     moveSourceSquare = null;
     selectedSquare = null;
     if (editMode) {
+      if (engine) {
+        engine.postMessage('stop');
+      }
       $(document).on('click.editOutside', handleOutsideBoardClick);
       clearEditSelection();
       clearHighlights();
       clearRatings();
+      latestAnalysisFen = null;
+      currentBestMove = null;
+      $('#evaluation').text('Editing');
+      updateBestMoveDisplay();
+      setAdvantageBarLoading(false);
+      updateAdvantageBar(null, { neutral: true, message: 'Editing' });
     } else {
       $(document).off('click.editOutside');
       clearEditSelection();
+      currentBestMove = null;
+      updateBestMoveDisplay();
       requestAnalysis({ highlight: shouldHighlightBest && bestMoveVisible, revealBest: bestMoveVisible });
     }
     $('#edit-button').text(editMode ? 'Play' : 'Edit');
@@ -1796,6 +2097,8 @@
   });
 
   clearEvaluationTimeline(1);
+  updateAdvantageBar(null, { neutral: true, message: 'Awaiting evaluation' });
+  setAdvantageBarLoading(false);
   renderBoard();
   initEngine();
   initBackgroundEngine();


### PR DESCRIPTION
## Summary
- add a live advantage bar with styling to show Stockfish evaluation trends
- connect engine output to the new bar, clearing stale data when analysis restarts or edit mode is active
- let editors toggle the side to move from the status display to ensure post-edit evaluations use the correct turn

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db24f3194083338c2e36011e8c9294