### PR TITLE
Reduce padding for advantage and probability panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
       color: #eef0f6;
       background: rgba(14, 18, 32, 0.35);
       border-radius: 16px;
-      padding: 14px 18px;
+      padding: 2px;
       backdrop-filter: blur(6px);
       transition: box-shadow 0.3s ease, background 0.3s ease;
     }
@@ -227,7 +227,7 @@
       margin-top: 12px;
       background: rgba(14, 18, 32, 0.35);
       border-radius: 16px;
-      padding: 16px 18px;
+      padding: 2px;
       backdrop-filter: blur(6px);
     }
 


### PR DESCRIPTION
## Summary
- reduce the advantage bar container padding to 2px for a tighter layout
- reduce the probability panel graph padding to 2px to match the advantage bar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbafccfebc8333813a60f190374a30