### PR TITLE
Update probability graph toggle button label

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@
       <button id="next-button" disabled>Next</button>
       <button id="best-move-button" disabled>Best</button>
       <button id="advantage-toggle-button">Hide Bar</button>
-      <button id="probability-button">Graph</button>
+      <button id="probability-button">Show Graph</button>
       <button id="piece-moves-button">Piece</button>
       <button id="flip-button">Flip</button>
       <button id="edit-button">Edit</button>
@@ -2165,7 +2165,7 @@
       });
       scheduleProbabilityEvaluation(PROBABILITY_GRAPH_DEPTH);
     } else {
-      $('#probability-button').text('Graph');
+      $('#probability-button').text('Show Graph');
     }
   });
   $('#prev-button').on('click', goToPreviousMove);


### PR DESCRIPTION
## Summary
- change the probability graph toggle to use "Show Graph" as its default label
- update the toggle handler to restore "Show Graph" when the panel is hidden

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbd60bbc188333a2a818db75a7a0cb