### PR TITLE
Fix mate parsing for delivered checkmates

### DIFF
--- a/index.html
+++ b/index.html
@@ -831,8 +831,8 @@
           }
 
           if (mateValue === 0) {
-            const gaugeSign = activeTurn === 'b' ? -rawSign : rawSign;
-            const winningSide = gaugeSign >= 0 ? 'white' : 'black';
+            const winningSide = activeTurn === 'w' ? 'black' : 'white';
+            const gaugeSign = winningSide === 'white' ? 1 : -1;
             const label = `${capitalizeWord(winningSide)} has delivered checkmate · 100% win chance`;
             const whiteWinProbability = winningSide === 'white' ? 1 : 0;
             return {


### PR DESCRIPTION
## Summary
- ensure mate-in-zero evaluations credit the side that delivered checkmate

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbdc62b09c83338a55d1d78a49df88