### PR TITLE
Improve engine initialization and mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,11 +25,11 @@
   }
 
   .container {
-    width: min(92vw, 540px);
+    width: min(94vw, 540px);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 28px;
+    gap: 26px;
   }
 
   .board-shell {
@@ -37,7 +37,7 @@
     background: rgba(8, 11, 20, 0.82);
     border: 1px solid rgba(255, 255, 255, 0.05);
     border-radius: 28px;
-    padding: 28px;
+    padding: 24px 28px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -213,13 +213,6 @@
     100% { opacity: 0.4; }
   }
 
-  #controls {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
-    gap: 14px;
-    width: 100%;
-  }
-
   button {
     appearance: none;
     border: none;
@@ -228,17 +221,28 @@
     cursor: pointer;
   }
 
+  #controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 16px;
+    width: 100%;
+  }
+
   .control-button {
     position: relative;
     width: 100%;
-    aspect-ratio: 1;
-    min-width: 48px;
+    min-height: 48px;
     border-radius: 16px;
     background: rgba(255, 255, 255, 0.08);
     color: #eef1ff;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 12px 16px;
+    text-align: center;
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.2;
     transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   }
@@ -260,11 +264,10 @@
     box-shadow: 0 12px 28px rgba(88, 120, 255, 0.38);
   }
 
-  .control-button svg {
-    width: 24px;
-    height: 24px;
-    stroke: currentColor;
-    fill: none;
+  .control-button__label {
+    display: block;
+    width: 100%;
+    pointer-events: none;
   }
 
   .probability-panel {
@@ -391,14 +394,20 @@
     display: flex;
   }
 
+  .board-container.editing .spare-pieces-7492f .piece-417db[data-piece^='b'] {
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    padding: 4px;
+  }
+
   @media (max-width: 640px) {
     .board-shell {
-      padding: 22px;
+      padding: 18px 22px;
       border-radius: 24px;
     }
 
     .container {
-      gap: 24px;
+      gap: 22px;
     }
 
     #board {
@@ -407,6 +416,29 @@
 
     .evaluation-indicator {
       width: 110px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .container {
+      width: min(98vw, 460px);
+      gap: 18px;
+    }
+
+    .board-shell {
+      padding: 14px 16px;
+      border-radius: 22px;
+    }
+
+    #controls {
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+
+    .control-button {
+      border-radius: 14px;
+      padding: 10px 12px;
+      font-size: 0.88rem;
     }
   }
 </style>
@@ -458,64 +490,39 @@
     </div>
     <div id="controls">
       <button id="prev-button" class="control-button" type="button" disabled aria-label="Previous move">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M15.5 5.5 9 12l6.5 6.5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Previous</span>
         <span class="visually-hidden">Previous move</span>
       </button>
       <button id="next-button" class="control-button" type="button" disabled aria-label="Next move">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M8.5 5.5 15 12l-6.5 6.5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Next</span>
         <span class="visually-hidden">Next move</span>
       </button>
       <button id="best-move-button" class="control-button" type="button" disabled aria-pressed="false" aria-label="Show best move">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M12 4.5 13.9 9.3 19 9.9 15 13.5 16.2 18.5 12 15.8 7.8 18.5 9 13.5 5 9.9 10.1 9.3Z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Show best move</span>
         <span class="visually-hidden">Show best move</span>
       </button>
       <button id="advantage-toggle-button" class="control-button" type="button" aria-pressed="false" aria-label="Show advantage bar">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M5 18V6m7 12V3m7 12V9" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Show advantage bar</span>
         <span class="visually-hidden">Show advantage bar</span>
       </button>
       <button id="probability-button" class="control-button" type="button" aria-pressed="false" aria-label="Show evaluation graph">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M4 16c2-5 4-7 8-7s6 2 8 7" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Show evaluation graph</span>
         <span class="visually-hidden">Show evaluation graph</span>
       </button>
       <button id="piece-moves-button" class="control-button" type="button" aria-pressed="false" aria-label="Show piece moves">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <circle cx="6" cy="6" r="2" stroke-width="2" />
-          <circle cx="18" cy="6" r="2" stroke-width="2" />
-          <circle cx="6" cy="18" r="2" stroke-width="2" />
-          <circle cx="18" cy="18" r="2" stroke-width="2" />
-          <path d="M6 8v8m12-8v8M8 6h8m-8 12h8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Show piece moves</span>
         <span class="visually-hidden">Show piece moves</span>
       </button>
       <button id="flip-button" class="control-button" type="button" aria-label="Flip board">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M7 9V5h4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-          <path d="M17 15v4h-4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-          <path d="M7 5a7 7 0 0 1 10 0M17 19a7 7 0 0 1-10 0" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Flip board</span>
         <span class="visually-hidden">Flip board</span>
       </button>
       <button id="edit-button" class="control-button" type="button" aria-pressed="false" aria-label="Enter edit mode">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="m5 15.5 9.5-9.5 4 4L9 19.5 5 20l.5-4.5Z" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Enter edit mode</span>
         <span class="visually-hidden">Enter edit mode</span>
       </button>
       <button id="fen-button" class="control-button" type="button" aria-label="Load FEN or PGN">
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <rect x="4" y="4" width="16" height="16" rx="3" stroke-width="2" />
-          <path d="M8 8h8M8 12h8M8 16h5" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
-        </svg>
+        <span class="control-button__label" aria-hidden="true">Load FEN/PGN</span>
         <span class="visually-hidden">Load FEN or PGN</span>
       </button>
 </div>
@@ -585,6 +592,8 @@
         element.setAttribute('aria-label', label);
         const hidden = element.querySelector('.visually-hidden');
         if (hidden) hidden.textContent = label;
+        const visible = element.querySelector('.control-button__label');
+        if (visible) visible.textContent = label;
       }
 
       function setButtonActive(element, isActive, activeLabel, inactiveLabel) {
@@ -622,18 +631,43 @@
       const ENGINE_WORKER_PATH = './engine/stockfish-17.1-8e4d048.js';
       const engineWorkerCandidates = [ENGINE_WORKER_PATH];
 
+      function resolveWorkerCandidate(path) {
+        try {
+          return new URL(path, window.location.href).toString();
+        } catch (error) {
+          return path;
+        }
+      }
+
       function createStockfishWorker() {
+        if (typeof Worker !== 'function') {
+          throw new Error('Web Workers are not supported in this environment.');
+        }
         let lastError = null;
         for (const candidate of engineWorkerCandidates) {
+          const absoluteCandidate = resolveWorkerCandidate(candidate);
           try {
-            const worker = new Worker(candidate);
+            const worker = new Worker(absoluteCandidate);
             worker.addEventListener('error', event => {
-              console.error(`Stockfish worker error (${candidate})`, event?.message || event);
+              console.error(`Stockfish worker error (${absoluteCandidate})`, event?.message || event);
             });
             return worker;
           } catch (error) {
-            console.error(`Failed to start Stockfish worker from ${candidate}`, error);
+            console.error(`Failed to start Stockfish worker from ${absoluteCandidate}`, error);
             lastError = error;
+          }
+          try {
+            const blob = new Blob([`importScripts(${JSON.stringify(absoluteCandidate)});`], { type: 'application/javascript' });
+            const objectUrl = URL.createObjectURL(blob);
+            const worker = new Worker(objectUrl);
+            worker.addEventListener('error', event => {
+              console.error(`Stockfish worker error (${absoluteCandidate})`, event?.message || event);
+            });
+            setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+            return worker;
+          } catch (blobError) {
+            console.error(`Failed to start fallback Stockfish worker from ${absoluteCandidate}`, blobError);
+            lastError = blobError;
           }
         }
         throw lastError || new Error('Unable to initialize Stockfish worker.');


### PR DESCRIPTION
## Summary
- add a resilient Stockfish worker bootstrap path so the engine loads even when direct worker creation fails
- replace icon-only action buttons with visible text labels and retune the layout for smaller screens
- ensure edit-mode spare black pieces have a contrasting background to stay visible on dark themes

## Testing
- no tests were run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dbf8816448833386a32b7d52779fce