### PR TITLE
Add support for Stockfish 17.1 lite worker paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,6 +992,7 @@
         : null;
 
       const STOCKFISH_WORKER_VARIANTS = [
+        { filename: 'stockfish-17.1-lite-51f59da.js', requiresThreadSupport: false },
         { filename: 'stockfish-17.1-8e4d048.js', requiresThreadSupport: true },
         { filename: 'stockfish-17.1-asm-341ff22.js', requiresThreadSupport: false }
       ];
@@ -1010,6 +1011,8 @@
         return [
           `./engine/${filename}`,
           `engine/${filename}`,
+          `./engine2/${filename}`,
+          `engine2/${filename}`,
           `./${filename}`,
           filename
         ];


### PR DESCRIPTION
## Summary
- prefer the Stockfish 17.1 lite worker variant when starting the engine
- include engine2 directory in the worker path search to support alternative hosting layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2188424483338298f958404d4d6f