### PR TITLE
Prefer single-threaded Stockfish worker fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,6 +992,7 @@
         : null;
 
       const STOCKFISH_WORKER_VARIANTS = [
+        { filename: 'stockfish-17.1-single-a496a04.js', requiresThreadSupport: false },
         { filename: 'stockfish-17.1-lite-51f59da.js', requiresThreadSupport: false },
         { filename: 'stockfish-17.1-8e4d048.js', requiresThreadSupport: true },
         { filename: 'stockfish-17.1-asm-341ff22.js', requiresThreadSupport: false }


### PR DESCRIPTION
## Summary
- add the single-thread Stockfish worker bundle as the primary non-threaded candidate so the engine can load without SharedArrayBuffer support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc25df8a2c8333862b768725270912