### PR TITLE
Limit worker loader to latest variant

### DIFF
--- a/index.html
+++ b/index.html
@@ -1040,7 +1040,11 @@
         }
 
         const threadedSupported = supportsThreadedWorkers();
-        for (const { filename, requiresThreadSupport } of STOCKFISH_WORKER_VARIANTS) {
+        const latestVariant = STOCKFISH_WORKER_VARIANTS.length
+          ? STOCKFISH_WORKER_VARIANTS[0]
+          : null;
+        const variantsToConsider = latestVariant ? [latestVariant] : [];
+        for (const { filename, requiresThreadSupport } of variantsToConsider) {
           if (requiresThreadSupport && !threadedSupported) {
             continue;
           }


### PR DESCRIPTION
## Summary
- update engine worker candidate generation to only consider the latest Stockfish variant
- ensure loader stops iterating through outdated variant filenames

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc44668a548333b9fed238a553b50f