### PR TITLE
Shorten control button labels to five letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,43 +652,43 @@
     </div>
     <div id="controls">
       <button id="prev-button" class="control-button" type="button" disabled aria-label="Previous move">
-        <span class="control-button__label" aria-hidden="true">Previous</span>
+        <span class="control-button__label" aria-hidden="true">Prior</span>
         <span class="visually-hidden">Previous move</span>
       </button>
       <button id="next-button" class="control-button" type="button" disabled aria-label="Next move">
-        <span class="control-button__label" aria-hidden="true">Next</span>
+        <span class="control-button__label" aria-hidden="true">Later</span>
         <span class="visually-hidden">Next move</span>
       </button>
       <button id="best-move-button" class="control-button" type="button" disabled aria-pressed="false" aria-label="Show best move">
-        <span class="control-button__label" aria-hidden="true">Show best move</span>
+        <span class="control-button__label" aria-hidden="true">Prime</span>
         <span class="visually-hidden">Show best move</span>
       </button>
       <button id="advantage-toggle-button" class="control-button" type="button" aria-pressed="false" aria-label="Show advantage bar">
-        <span class="control-button__label" aria-hidden="true">Show advantage bar</span>
+        <span class="control-button__label" aria-hidden="true">Meter</span>
         <span class="visually-hidden">Show advantage bar</span>
       </button>
       <button id="probability-button" class="control-button" type="button" aria-pressed="false" aria-label="Show evaluation graph">
-        <span class="control-button__label" aria-hidden="true">Show evaluation graph</span>
+        <span class="control-button__label" aria-hidden="true">Graph</span>
         <span class="visually-hidden">Show evaluation graph</span>
       </button>
       <button id="piece-moves-button" class="control-button" type="button" aria-pressed="false" aria-label="Show piece moves">
-        <span class="control-button__label" aria-hidden="true">Show piece moves</span>
+        <span class="control-button__label" aria-hidden="true">Moves</span>
         <span class="visually-hidden">Show piece moves</span>
       </button>
       <button id="flip-button" class="control-button" type="button" aria-label="Flip board">
-        <span class="control-button__label" aria-hidden="true">Flip board</span>
+        <span class="control-button__label" aria-hidden="true">Pivot</span>
         <span class="visually-hidden">Flip board</span>
       </button>
       <button id="edit-button" class="control-button" type="button" aria-pressed="false" aria-label="Enter edit mode">
-        <span class="control-button__label" aria-hidden="true">Enter edit mode</span>
+        <span class="control-button__label" aria-hidden="true">Alter</span>
         <span class="visually-hidden">Enter edit mode</span>
       </button>
       <button id="fen-button" class="control-button" type="button" aria-label="Load FEN or PGN">
-        <span class="control-button__label" aria-hidden="true">Load FEN/PGN</span>
+        <span class="control-button__label" aria-hidden="true">Input</span>
         <span class="visually-hidden">Load FEN or PGN</span>
       </button>
       <button id="engine-button" class="control-button" type="button" aria-pressed="false" aria-label="Show engine settings">
-        <span class="control-button__label" aria-hidden="true">Engine settings</span>
+        <span class="control-button__label" aria-hidden="true">Setup</span>
         <span class="visually-hidden">Show engine settings</span>
       </button>
     </div>
@@ -717,10 +717,10 @@
       <div id="engine-error" class="engine-settings__error" role="alert" hidden></div>
       <div class="engine-settings__actions">
         <button type="button" id="engine-start-button" class="engine-action-button engine-action-button--primary">
-          <span class="engine-action-button__label">Start engine</span>
+          <span class="engine-action-button__label">Start</span>
         </button>
         <button type="button" id="engine-stop-button" class="engine-action-button" disabled>
-          <span class="engine-action-button__label">Stop engine</span>
+          <span class="engine-action-button__label">Cease</span>
         </button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the control panel button text with single five-letter words while retaining the hidden accessible labels
- shorten the engine action buttons to five-letter labels that match the new visual language
- manually verify the abbreviated labels render correctly within the existing layout

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc4b18d42083339f9cd944abd6a497