### PR TITLE
Handle off-turn piece analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,6 +797,7 @@
       let currentDepth = 0;
       let pieceMoveRatings = new Map();
       let pieceAnalysisMode = null;
+      let pieceAnalysisTurn = null;
       let pieceAnalysisQueue = [];
       let pieceAnalysisCurrentMove = null;
       let pieceAnalysisActiveRequestId = 0;
@@ -1916,6 +1917,15 @@
         advantageBarElement.style.maxWidth = `${Math.round(bounds.width)}px`;
       }
 
+      function getFenTurn(fen) {
+        if (typeof fen !== 'string') return null;
+        const trimmed = fen.trim();
+        if (!trimmed.length) return null;
+        const parts = trimmed.split(/\s+/);
+        if (parts.length < 2) return null;
+        return parts[1] === 'b' ? 'b' : 'w';
+      }
+
       function normalizeFenTurn(fen, turn) {
         if (typeof fen !== 'string') return fen;
         const trimmed = fen.trim();
@@ -2491,6 +2501,7 @@
     pieceAnalysisFen = null;
     pieceAnalysisTargetDepth = 0;
     pieceAnalysisWaitingForResult = false;
+    pieceAnalysisTurn = null;
   }
 
   function ensurePieceMoveRatingElement(moveKey) {
@@ -2573,6 +2584,7 @@
     pieceAnalysisFen = null;
     pieceAnalysisTargetDepth = 0;
     pieceAnalysisWaitingForResult = false;
+    pieceAnalysisTurn = null;
     isPieceAnalysis = false;
     if (engine) {
       try {
@@ -2605,7 +2617,7 @@
     const entry = buildEvaluationEntryFromScore({
       cp: cp ? parseInt(cp[1], 10) : null,
       mate: mate ? parseInt(mate[1], 10) : null,
-      turn: game.turn()
+      turn: pieceAnalysisTurn || game.turn()
     });
     applyPieceMoveEvaluation(pieceAnalysisCurrentMove, entry);
     return true;
@@ -2781,7 +2793,7 @@
           const entry = buildEvaluationEntryFromScore({
             cp: cp ? parseInt(cp[1], 10) : null,
             mate: mate ? parseInt(mate[1], 10) : null,
-            turn: game.turn()
+            turn: pieceAnalysisTurn || game.turn()
           });
           applyPieceMoveEvaluation(moveKey, entry);
           return;
@@ -2949,7 +2961,8 @@
       searchMoves = null,
       multiPv = 1,
       pieceAnalysis = false,
-      replay = false
+      replay = false,
+      analysisFen = null
     } = options;
 
     latestAnalysisFen = game.fen();
@@ -3025,12 +3038,16 @@
       updateEvaluationProgressLabel();
     }
 
+    const fenOverride = typeof analysisFen === 'string' ? analysisFen : null;
     const normalizedFen = normalizeFenTurn(latestAnalysisFen, game.turn());
 
     engine.postMessage('stop');
     if (pieceAnalysis) {
       const moveList = Array.isArray(searchMoves) ? searchMoves.slice() : [];
-      beginPieceAnalysisSearch({ fen: normalizedFen, moves: moveList, depth });
+      const fenTurn = getFenTurn(fenOverride) || game.turn();
+      const targetFen = normalizeFenTurn(fenOverride || latestAnalysisFen, fenTurn);
+      beginPieceAnalysisSearch({ fen: targetFen, moves: moveList, depth });
+      pieceAnalysisTurn = fenTurn;
       updateNavigationButtons();
       return;
     }
@@ -3050,7 +3067,19 @@
   function analyzeMoves() {
     clearRatings();
     if (!selectedSquare) return;
-    const moves = game.moves({ verbose: true }).filter(m => m.from === selectedSquare);
+    const piece = game.get(selectedSquare);
+    if (!piece) return;
+    let analysisGame = game;
+    let analysisFenOverride = null;
+    if (piece.color !== game.turn()) {
+      const candidateFen = normalizeFenTurn(game.fen(), piece.color);
+      const tempGame = new Chess();
+      if (tempGame.load(candidateFen)) {
+        analysisGame = tempGame;
+        analysisFenOverride = candidateFen;
+      }
+    }
+    const moves = analysisGame.moves({ verbose: true, square: selectedSquare });
     if (!moves.length) return;
     clearHighlights();
     applySelectionHighlights();
@@ -3059,7 +3088,8 @@
       depth: engineConfig.depth,
       searchMoves,
       multiPv: moves.length,
-      pieceAnalysis: true
+      pieceAnalysis: true,
+      analysisFen: analysisFenOverride
     });
   }
 


### PR DESCRIPTION
## Summary
- clone the game state when analyzing a piece that is not to move and pass a FEN override into piece analysis
- track the analyzed color to interpret Stockfish scores from the correct perspective

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4cb3ab18833386ecdec92faf9a3c