### PR TITLE
Show probability graph after PGN import

### DIFF
--- a/index.html
+++ b/index.html
@@ -3437,6 +3437,14 @@
     updateNavigationButtons();
     if (lastImportWasPgn) {
       startReplayFromIndex(0, PGN_REPLAY_DEPTH);
+      probabilityPanelVisible = true;
+      if (probabilityPanel) {
+        probabilityPanel.hidden = false;
+        probabilityPanel.setAttribute('aria-hidden', 'false');
+      }
+      syncProbabilityButton();
+      renderEvaluationNavigation();
+      scheduleProbabilityEvaluation(PROBABILITY_GRAPH_DEPTH);
     } else {
       requestAnalysis({ highlight: shouldHighlightBest && bestMoveVisible, revealBest: bestMoveVisible });
     }


### PR DESCRIPTION
## Summary
- automatically reveal the probability graph after importing PGN notation
- refresh the evaluation navigation and schedule probability evaluations for the imported moves

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc53040c448333ad02284de04b763d