### PR TITLE
Fix deferred initialization of chess UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -884,9 +884,25 @@
       </div>
     </div>
   </div>
-  <script defer>
-    $(function() {
-      let board, engine;
+  <script>
+    (function setup() {
+      function initialize() {
+        const $ = window.jQuery;
+        if (typeof $ !== 'function') {
+          console.error('jQuery failed to load; the chess interface cannot initialize.');
+          return;
+        }
+        const Chessboard = window.Chessboard;
+        if (typeof Chessboard !== 'function') {
+          console.error('Chessboard.js failed to load; the chess interface cannot initialize.');
+          return;
+        }
+        const Chess = window.Chess;
+        if (typeof Chess !== 'function') {
+          console.error('Chess.js failed to load; the chess interface cannot initialize.');
+          return;
+        }
+        let board, engine;
       let lastBoardConfig = { editMode: null, orientation: null };
       const game = new Chess();
       const boardEl = $('#board');
@@ -4014,7 +4030,14 @@
       rebuildPosition(targetIndex);
     });
   }
-});
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialize, { once: true });
+      } else {
+        initialize();
+      }
+    })();
 
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the inline jQuery ready handler with a setup wrapper that waits for DOMContentLoaded
- guard against missing jQuery, Chessboard.js, or Chess.js before initializing the UI to avoid crashes

## Testing
- browser_container.run_playwright_script (Playwright smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68dcd90481c483339b7b31f678f2be43