### PR TITLE
Fix Stockfish worker default path

### DIFF
--- a/index.html
+++ b/index.html
@@ -979,7 +979,7 @@
         return null;
       })();
       const defaultWorkerLocation = selectedStockfishVariant
-        ? `/engine/${selectedStockfishVariant.filename}`
+        ? `engine/${selectedStockfishVariant.filename}`
         : null;
       const ENGINE_THREADS_MIN = 1;
       const ENGINE_THREADS_MAX = selectedStockfishVariant && selectedStockfishVariant.requiresThreadSupport === false


### PR DESCRIPTION
## Summary
- update the default Stockfish worker path to be relative instead of absolute so the engine worker can be found when hosted in a subdirectory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcdd49ebbc833388ca72c882bc400e