### PR TITLE
Fix worker URL resolution for subdirectory hosting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1493,7 +1493,18 @@
 
       function resolveWorkerCandidate(path) {
         try {
-          return new URL(path, window.location.href).toString();
+          const { origin, pathname } = window.location;
+          let basePath = pathname || '/';
+
+          if (!basePath.endsWith('/')) {
+            const lastSegment = basePath.split('/').pop();
+            if (lastSegment && !lastSegment.includes('.')) {
+              basePath += '/';
+            }
+          }
+
+          const baseUrl = `${origin}${basePath}`;
+          return new URL(path, baseUrl).toString();
         } catch (error) {
           return path;
         }


### PR DESCRIPTION
## Summary
- adjust resolveWorkerCandidate to build a directory-aware base URL from window.location before resolving worker paths

## Testing
- Custom Playwright script to load http://127.0.0.1:8000/chess and ensure workers initialize without errors

------
https://chatgpt.com/codex/tasks/task_e_68dce2c82b448333afbfbbafe2214c07