### PR TITLE
Add helper to reset auto-play state

### DIFF
--- a/index.html
+++ b/index.html
@@ -1025,6 +1025,15 @@
       let autoPlayRequestedAt = 0;
       let autoPlayDelayTimer = null;
       let autoPlayDepthSatisfied = false;
+      function resetAutoPlayState() {
+        if (autoPlayDelayTimer) {
+          clearTimeout(autoPlayDelayTimer);
+          autoPlayDelayTimer = null;
+        }
+        waitingForAutoBestMove = false;
+        autoMoveCandidate = null;
+        autoPlayDepthSatisfied = false;
+      }
       const evaluationNavElement = document.getElementById('evaluation-nav');
       let evaluationNavNeedsVisibleRender = false;
       let advantageBarVisible = false;
@@ -3321,6 +3330,8 @@
         }
 
         if (!latestAnalysisFen || latestAnalysisFen !== game.fen()) {
+          resetAutoPlayState();
+          updateNavigationButtons();
           return;
         }
 
@@ -3332,13 +3343,7 @@
           const moveToPlay = move && move !== '(none)' ? move : fallback;
 
           const finalizeAutoMove = () => {
-            if (autoPlayDelayTimer) {
-              clearTimeout(autoPlayDelayTimer);
-              autoPlayDelayTimer = null;
-            }
-            waitingForAutoBestMove = false;
-            autoMoveCandidate = null;
-            autoPlayDepthSatisfied = false;
+            resetAutoPlayState();
             if (moveToPlay) {
               applyAutoMove(moveToPlay);
             }


### PR DESCRIPTION
## Summary
- add a resetAutoPlayState helper to consolidate auto-play cleanup
- ensure auto-play state resets and navigation controls update on bestmove FEN mismatches
- reuse the helper when finalizing auto moves for consistent cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf0cf6a048333b8a6c0ae44cc152b