### PR TITLE
Stop background probability evaluation when panel hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -3800,6 +3800,8 @@
     if (probabilityPanelVisible) {
       scheduleEvaluationNavigationRender();
       scheduleProbabilityEvaluation(PROBABILITY_GRAPH_DEPTH);
+    } else {
+      cancelBackgroundEvaluation();
     }
     syncProbabilityButton();
   });


### PR DESCRIPTION
## Summary
- cancel any pending probability background evaluations when the panel is hidden
- keep scheduling the evaluation and navigation render when the panel is shown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0d9c25cc833391c9bc6a93bbb22c