### PR TITLE
Guard duplicate stop requests during analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -3839,7 +3839,9 @@
 
     const normalizedFen = normalizeFenTurn(latestAnalysisFen, game.turn());
 
-    postEngineCommand('stop', { queueIfPending: false });
+    if (!engineAwaitingReadyAfterStop) {
+      postEngineCommand('stop', { queueIfPending: false });
+    }
     engineCommandQueue = [];
     beginEngineReadyWait();
     if (pieceAnalysis) {


### PR DESCRIPTION
## Summary
- avoid issuing multiple immediate stop commands while a ready-wait is already pending during requestAnalysis
- continue dropping stale commands and re-arm the engine ready wait to preserve the handshake flow

## Testing
- not run (UI flow requires manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68dd3e8c967c83338c5cd80bac404817