### PR TITLE
Add fallback to single-thread Stockfish worker when threads unsupported

### DIFF
--- a/index.html
+++ b/index.html
@@ -968,7 +968,9 @@
       let navigationIndex = 0;
       let enginePanelVisible = false;
         const STOCKFISH_WORKER_VARIANTS = [
-          { filename: 'stockfish-nnue-16.js', requiresThreadSupport: true }
+          { filename: 'stockfish-nnue-16.js', requiresThreadSupport: true },
+          { filename: 'stockfish-17-lite-single.js', requiresThreadSupport: false },
+          { filename: 'stockfish-16.1-lite-single.js', requiresThreadSupport: false }
         ];
         const STOCKFISH_ENGINE_DIRECTORY = '.';
         const STOCKFISH_WORKER_DIRECTORIES = Object.freeze([
@@ -1827,10 +1829,27 @@
           overrideCandidates.forEach(addCandidate);
         }
 
-        const variantsToConsider = selectedStockfishVariant
-          ? [selectedStockfishVariant]
-          : [];
-        for (const { filename, requiresThreadSupport } of variantsToConsider) {
+        const variantsToConsider = (() => {
+          const availableVariants = Array.isArray(STOCKFISH_WORKER_VARIANTS)
+            ? STOCKFISH_WORKER_VARIANTS.filter(Boolean)
+            : [];
+          if (!selectedStockfishVariant) {
+            return availableVariants;
+          }
+          const prioritized = [selectedStockfishVariant];
+          for (const variant of availableVariants) {
+            if (variant === selectedStockfishVariant) {
+              continue;
+            }
+            prioritized.push(variant);
+          }
+          return prioritized;
+        })();
+        for (const variant of variantsToConsider) {
+          if (!variant) {
+            continue;
+          }
+          const { filename, requiresThreadSupport } = variant;
           if (requiresThreadSupport && !threadSupportAvailable) {
             continue;
           }


### PR DESCRIPTION
## Summary
- add non-threaded Stockfish worker variants so the UI can load when SharedArrayBuffer is unavailable
- prioritize the selected variant but fall back to the remaining configured workers when resolving engine scripts

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de73eab4d48333ab880ab502b37384