### PR TITLE
Fix piece move analysis after engine startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3681,6 +3681,8 @@
             const pending = pendingReplayStart;
             pendingReplayStart = null;
             startReplayFromIndex(pending.index, pending.depth);
+          } else if (pieceMovesMode) {
+            analyzeMoves();
           } else {
             requestAnalysis({ highlight: shouldHighlightBest && bestMoveVisible, revealBest: bestMoveVisible, depth: engineConfig.depth });
           }


### PR DESCRIPTION
## Summary
- ensure piece move mode restarts per-piece analysis once the engine signals it is ready

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de83d1d07083338f7bb9cabcbb1146