### PR TITLE
Guard piece analysis finalization when a new request is pending

### DIFF
--- a/index.html
+++ b/index.html
@@ -3708,7 +3708,11 @@
         if (isPieceAnalysis) {
           pieceAnalysisSearchInFlight = false;
           if (pieceAnalysisMode === PIECE_ANALYSIS_MODE_MULTIPV) {
+            const hasActiveRequest = !!pieceAnalysisCurrentRequestId && !pieceAnalysisPendingRequestId;
             currentSearchContext = null;
+            if (!hasActiveRequest) {
+              return;
+            }
             finalizePieceAnalysis();
             return;
           }


### PR DESCRIPTION
## Summary
- add a guard so multipv piece analysis only finalizes when the active request has completed
- ensure pending piece analysis searches keep their context so multipv updates resume once the engine restarts

## Testing
- not run (manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68dea644a8e4833393699b84ad1d5f52