### PR TITLE
Fix PGN import when headers lack blank line

### DIFF
--- a/index.html
+++ b/index.html
@@ -4132,13 +4132,31 @@
     };
 
     const loadPgn = () => {
+      const normalizePgn = input => {
+        let normalized = input;
+        const headerMatch = normalized.match(/^((?:\s*\[[^\]]+\][^\S\r\n]*\r?\n)+)([\s\S]*)$/);
+        if (headerMatch) {
+          const headerBlock = headerMatch[1];
+          const remainder = headerMatch[2];
+          const hasBlankLine = /^\s*(?:\r?\n)/.test(remainder);
+          const startsWithMoveText = /^\s*\d+\./.test(remainder);
+          if (!hasBlankLine && startsWithMoveText) {
+            const newline = headerBlock.includes('\r\n') ? '\r\n' : '\n';
+            normalized = `${headerBlock}${newline}${remainder}`;
+          }
+        }
+        return normalized;
+      };
+
+      const normalizedPgn = normalizePgn(trimmed);
+
       let importGame = new Chess();
       let loaded = false;
       if (typeof importGame.load_pgn === 'function') {
-        loaded = importGame.load_pgn(trimmed, { sloppy: true });
+        loaded = importGame.load_pgn(normalizedPgn, { sloppy: true });
         if (!loaded) {
           importGame = new Chess();
-          loaded = importGame.load_pgn(trimmed);
+          loaded = importGame.load_pgn(normalizedPgn);
         }
       }
       if (!loaded) return false;


### PR DESCRIPTION
## Summary
- detect when imported PGNs lack the blank line between headers and movetext
- normalize the PGN once and reuse it for both sloppy and strict import attempts

## Testing
- node <<'NODE'
const { Chess } = require('./libs/chess.min.js');
const normalizePgn = input => {
  let normalized = input;
  const headerMatch = normalized.match(/^((?:\s*\[[^\]]+\][^\S\r\n]*\r?\n)+)([\s\S]*)$/);
  if (headerMatch) {
    const headerBlock = headerMatch[1];
    const remainder = headerMatch[2];
    const hasBlankLine = /^\s*(?:\r?\n)/.test(remainder);
    const startsWithMoveText = /^\s*\d+\./.test(remainder);
    if (!hasBlankLine && startsWithMoveText) {
      const newline = headerBlock.includes('\r\n') ? '\r\n' : '\n';
      normalized = `${headerBlock}${newline}${remainder}`;
    }
  }
  return normalized;
};

const rawPgn = `[Event "Live Chess"]\n[Site "Chess.com"]\n[Date "2021.02.01"]\n[Round "-"]\n[White "WhitePlayer"]\n[Black "BlackPlayer"]\n[Result "1-0"]\n[ECO "C50"]\n[WhiteElo "1500"]\n[BlackElo "1500"]\n[TimeControl "600"]\n[EndTime "10:30:00"]\n[Termination "White won by checkmate"]\n1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Ng5 d5 5. exd5 Nxd5 6. Nxf7 Kxf7 7. Qf3+ Ke6 8. Nc3 Nb4 9. O-O c6 10. d4 Nxc2 11. dxe5 Nd4 12. Qe4 b5 13. Bxd5+ cxd5 14. Qxd4 Bb7 15. Qg4+ Kf7 16. e6+ Ke8 17. Nxb5 Rc8 18. Bg5 Be7 19. Qf5 Rf8 20. Qxh7 Qb6 21. Qg6+ Kd8 22. Qxg7 Qc5 23. Qxf8# 1-0`;

const chess = new Chess();
const normalized = normalizePgn(rawPgn.trim());
const result = chess.load_pgn(normalized, { sloppy: true });
console.log('Loaded after normalization:', result);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68dede51392c8333a040a655e3fb8838