### PR TITLE
Fix Lichess archive moves import

### DIFF
--- a/index.html
+++ b/index.html
@@ -2569,7 +2569,7 @@
         }
         const params = new URLSearchParams({
           max: String(ARCHIVE_SEARCH_LIMIT),
-          moves: 'false',
+          moves: 'true',
           pgnInJson: 'true',
           clocks: 'false',
           evals: 'false',


### PR DESCRIPTION
## Summary
- request move text when fetching recent Lichess games so imported PGNs include their moves

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c62361348333aeda8fbbaf3826d6