### PR TITLE
Increase PGN import evaluation depth

### DIFF
--- a/index.html
+++ b/index.html
@@ -1273,7 +1273,7 @@
         const ENGINE_THREADS_MIN = 2;
         const DEFAULT_ANALYSIS_DEPTH = 16;
         const PGN_REPLAY_DEPTH = 12;
-        const PGN_IMPORT_ANALYSIS_DEPTH = 8;
+        const PGN_IMPORT_ANALYSIS_DEPTH = 16;
         const DEFAULT_THREADS = 3;
         const DEFAULT_HASH_MB = 256;
         const ENGINE_MEMORY_ERROR_FALLBACK_HASH_MB = DEFAULT_HASH_MB;


### PR DESCRIPTION
## Summary
- raise the PGN import evaluation depth constant to 16 so imported games analyze more deeply

## Testing
- manual verification by importing a sample PGN and confirming the worker requests go depth 16

------
https://chatgpt.com/codex/tasks/task_e_68e2c9564f388333a1fc85a767fdd46d