### PR TITLE
Refine advantage gauge layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,9 +128,10 @@
 
   #info-line {
     display: flex;
-    gap: 18px;
     align-items: center;
-    justify-content: center;
+    gap: 14px;
+    width: 100%;
+    flex-wrap: wrap;
   }
 
   #status {
@@ -190,42 +191,77 @@
   }
 
   .info-line-item {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 8px;
+  }
+
+  .info-line-item--gauge {
+    flex: 1 1 160px;
+    min-width: 0;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-left: auto;
   }
 
   .evaluation-indicator {
     --eval-scale: 0.5;
-    position: relative;
-    width: 140px;
-    height: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 42px;
+    padding: 3px 10px;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.08);
-    overflow: hidden;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    background: rgba(16, 22, 36, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #dbe1ff;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
+    text-transform: uppercase;
+    line-height: 1;
+    transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
   }
 
-  .evaluation-indicator::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, #69f0ff, #7b7dff 55%, #ff7ce8);
-    transform: scaleX(var(--eval-scale));
-    transform-origin: left center;
-    transition: transform 0.35s ease;
+  .evaluation-indicator__value {
+    display: inline-block;
+    min-width: 3ch;
+    text-align: center;
+    letter-spacing: inherit;
+  }
+
+  .evaluation-indicator.is-white-favored {
+    background: rgba(88, 124, 255, 0.22);
+    border-color: rgba(150, 188, 255, 0.55);
+    color: #f3f7ff;
+  }
+
+  .evaluation-indicator.is-black-favored {
+    background: rgba(108, 90, 255, 0.16);
+    border-color: rgba(174, 150, 255, 0.5);
+    color: #e1deff;
+  }
+
+  .evaluation-indicator.is-balanced {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: #dbe1ff;
   }
 
   .advantage-bar {
     position: relative;
-    width: 100%;
-    max-width: 320px;
-    height: 12px;
+    flex: 1 1 auto;
+    height: 10px;
     border-radius: 999px;
     overflow: hidden;
-    background: rgba(255, 255, 255, 0.08);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-    display: block;
+    background: rgba(10, 16, 28, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(7, 11, 20, 0.65);
+    display: inline-block;
+    min-width: 120px;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
   }
 
   .advantage-bar[hidden] {
@@ -242,41 +278,53 @@
     position: absolute;
     inset: 0;
     --white-ratio: 50%;
-    background: linear-gradient(90deg, rgba(236, 244, 255, 0.85) 0%, rgba(236, 244, 255, 0.85) var(--white-ratio), rgba(18, 26, 44, 0.85) var(--white-ratio), rgba(18, 26, 44, 0.85) 100%);
+    background: linear-gradient(90deg, rgba(232, 240, 255, 0.92) 0%, rgba(232, 240, 255, 0.92) var(--white-ratio), rgba(19, 24, 40, 0.88) var(--white-ratio), rgba(19, 24, 40, 0.88) 100%);
+    transition: background-position 0.35s ease;
   }
 
   .advantage-bar__track::after {
     content: '';
     position: absolute;
-    top: -4px;
-    bottom: -4px;
-    width: 4px;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.6);
-    left: calc(var(--white-ratio) - 2px);
-    transition: left 0.35s ease;
+    top: 1px;
+    bottom: 1px;
+    width: 1px;
+    left: calc(50% - 0.5px);
+    background: rgba(255, 255, 255, 0.65);
+    opacity: 0.8;
+    pointer-events: none;
   }
 
   .advantage-bar.is-white-favored {
-    box-shadow: inset 0 0 0 1px rgba(165, 199, 255, 0.4), 0 12px 24px rgba(80, 140, 255, 0.25);
+    border-color: rgba(156, 195, 255, 0.6);
+    box-shadow: inset 0 0 0 1px rgba(120, 170, 255, 0.45);
+    background: rgba(18, 30, 52, 0.9);
   }
 
   .advantage-bar.is-black-favored {
-    box-shadow: inset 0 0 0 1px rgba(130, 110, 255, 0.4), 0 12px 24px rgba(130, 110, 255, 0.22);
+    border-color: rgba(178, 160, 255, 0.55);
+    box-shadow: inset 0 0 0 1px rgba(140, 120, 255, 0.42);
+    background: rgba(15, 16, 34, 0.92);
   }
 
   .advantage-bar.is-balanced {
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(7, 11, 20, 0.65);
   }
 
-  .advantage-bar.is-loading .advantage-bar__track::after {
+  .advantage-bar.is-loading::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.25) 50%, transparent 100%);
     animation: indicator-slide 1.1s ease-in-out infinite;
+    pointer-events: none;
+    opacity: 0.6;
   }
 
   @keyframes indicator-slide {
-    0% { opacity: 0.4; }
-    50% { opacity: 1; }
-    100% { opacity: 0.4; }
+    0% { transform: translateX(-60%); opacity: 0.1; }
+    50% { transform: translateX(0%); opacity: 0.6; }
+    100% { transform: translateX(60%); opacity: 0.1; }
   }
 
   @media (min-width: 1024px) and (orientation: landscape) {
@@ -966,9 +1014,6 @@
       max-width: 100%;
     }
 
-    .evaluation-indicator {
-      width: 110px;
-    }
   }
 
   @media (max-width: 480px) {
@@ -1031,30 +1076,20 @@
             <span id="status" class="status-text" role="status" aria-live="polite" aria-atomic="true" data-turn="white" data-state="normal" aria-label="White to move">
               <span class="status-text__label">White to move</span>
             </span>
-            <span class="info-line-item" id="evaluation-container" aria-hidden="true" hidden>
-              <span id="evaluation" class="evaluation-indicator" role="img" aria-label="Eval: --" data-probability="0.5" aria-live="off" aria-atomic="true">
-                <span class="visually-hidden">Eval: --</span>
+            <span class="info-line-item info-line-item--gauge" id="evaluation-container" aria-hidden="true" hidden>
+              <span class="advantage-bar is-balanced advantage-bar--inline" id="advantage-bar" aria-live="polite" aria-busy="false" aria-atomic="true" aria-hidden="true" hidden>
+                <span class="advantage-bar__track" id="advantage-track"></span>
+              </span>
+              <span id="evaluation" class="evaluation-indicator is-balanced" role="img" aria-label="Win chance --" data-probability="0.5" aria-live="off" aria-atomic="true">
+                <span class="visually-hidden">Win chance --</span>
+                <span class="evaluation-indicator__value" aria-hidden="true" data-visible-value>--</span>
               </span>
             </span>
           </div>
         </div>
-        <div class="advantage-bar is-balanced advantage-bar--minimal" id="advantage-bar" aria-live="polite" aria-busy="false" aria-atomic="true" aria-hidden="true" hidden>
-          <div class="advantage-bar__header" aria-hidden="true">
-            <span class="visually-hidden">Advantage</span>
-            <span class="advantage-bar__status visually-hidden" id="advantage-status">Awaiting evaluation</span>
-          </div>
-          <div class="advantage-bar__track" id="advantage-track"></div>
-          <div class="advantage-bar__footer" aria-hidden="true">
-            <span class="advantage-bar__side advantage-bar__side--white">
-              <span class="advantage-bar__side-label visually-hidden">White</span>
-              <span class="advantage-bar__percent visually-hidden" id="advantage-white-percent">50%</span>
-            </span>
-            <span class="advantage-bar__side advantage-bar__side--black">
-              <span class="advantage-bar__percent visually-hidden" id="advantage-black-percent">50%</span>
-              <span class="advantage-bar__side-label visually-hidden">Black</span>
-            </span>
-          </div>
-        </div>
+        <span class="visually-hidden" id="advantage-status">Awaiting evaluation</span>
+        <span class="visually-hidden" id="advantage-white-percent">50%</span>
+        <span class="visually-hidden" id="advantage-black-percent">50%</span>
         <div class="probability-panel" id="probability-panel" hidden>
           <div class="probability-panel__graph" id="evaluation-nav" role="group" aria-label="Evaluation timeline"></div>
         </div>
@@ -1202,6 +1237,7 @@
       const probabilityPanel = document.getElementById('probability-panel');
       const evaluationContainer = document.getElementById('evaluation-container');
       const evaluationElement = document.getElementById('evaluation');
+      const evaluationValueElement = evaluationElement ? evaluationElement.querySelector('[data-visible-value]') : null;
       const bestMoveButtonElement = document.getElementById('best-move-button');
       const probabilityButtonElement = document.getElementById('probability-button');
       const pieceMovesButtonElement = document.getElementById('piece-moves-button');
@@ -2387,12 +2423,15 @@
         evaluationContainer.setAttribute('aria-hidden', 'true');
       }
       if (evaluationElement) {
-        const defaultLabel = 'Eval: --';
+        const defaultLabel = 'Win chance --';
         const hiddenLabel = evaluationElement.querySelector('.visually-hidden');
         if (hiddenLabel) hiddenLabel.textContent = defaultLabel;
         evaluationElement.setAttribute('aria-label', defaultLabel);
         evaluationElement.dataset.probability = '0.5';
         evaluationElement.style.setProperty('--eval-scale', '0.5');
+        if (evaluationValueElement) {
+          evaluationValueElement.textContent = '--';
+        }
         setEvaluationLiveMode(false);
       }
       syncBestMoveButton();
@@ -2411,14 +2450,24 @@
         const hiddenLabel = evaluationElement.querySelector('.visually-hidden');
         if (hiddenLabel) {
           hiddenLabel.textContent = label;
-        } else {
-          evaluationElement.textContent = label;
         }
         evaluationElement.setAttribute('aria-label', label);
-        if (probability !== null) {
+        let displayValue = '--';
+        const hasProbability = typeof probability === 'number' && !Number.isNaN(probability);
+        if (hasProbability) {
           const clamped = Math.max(0, Math.min(1, Number(probability) || 0));
           evaluationElement.dataset.probability = clamped.toString();
           evaluationElement.style.setProperty('--eval-scale', clamped.toString());
+          if (label && !label.includes('--')) {
+            displayValue = formatWinProbability(clamped);
+          }
+        } else if (label && !label.includes('--')) {
+          displayValue = label;
+        }
+        if (evaluationValueElement) {
+          evaluationValueElement.textContent = displayValue;
+        } else if (!hiddenLabel) {
+          evaluationElement.textContent = displayValue;
         }
       }
 
@@ -3049,7 +3098,7 @@
       }
 
       function formatEvaluationLabel(probability) {
-        return `Eval: ${formatWinProbability(probability)}`;
+        return `Win chance ${formatWinProbability(probability)}`;
       }
 
       function deriveWhiteWinProbability(entry) {
@@ -3073,7 +3122,7 @@
 
       function updateEvaluationDisplay(entry) {
         if (!entry) {
-          setEvaluationText('Eval: --', 0.5);
+          setEvaluationText('Win chance --', 0.5);
           return;
         }
         const probability = deriveWhiteWinProbability(entry);
@@ -3213,6 +3262,11 @@
           advantageBarElement.classList.toggle('is-white-favored', isWhiteFavored);
           advantageBarElement.classList.toggle('is-black-favored', isBlackFavored);
           advantageBarElement.classList.toggle('is-balanced', !isWhiteFavored && !isBlackFavored);
+          if (evaluationElement) {
+            evaluationElement.classList.toggle('is-white-favored', isWhiteFavored);
+            evaluationElement.classList.toggle('is-black-favored', isBlackFavored);
+            evaluationElement.classList.toggle('is-balanced', !isWhiteFavored && !isBlackFavored);
+          }
         }
       }
 
@@ -3765,7 +3819,7 @@
           setAdvantageBarLoading(false);
           updateAdvantageBar(entry);
         } else {
-          setEvaluationText('Eval: --', 0.5);
+          setEvaluationText('Win chance --', 0.5);
           setAdvantageBarLoading(false);
           updateAdvantageBar(null, { neutral: true, message: 'Awaiting evaluation' });
         }
@@ -3956,7 +4010,7 @@
           baseFen = newBaseFen;
         }
         clearEvaluationTimeline(1);
-        setEvaluationText('Eval: --', 0.5);
+        setEvaluationText('Win chance --', 0.5);
         currentBestMove = null;
         latestAnalysisFen = null;
         setAdvantageBarLoading(false);
@@ -4566,7 +4620,7 @@
     currentBestMove = null;
     updateBestMoveDisplay();
     if (!pieceMovesMode) {
-      setEvaluationText('Eval: --', 0.5);
+      setEvaluationText('Win chance --', 0.5);
       setAdvantageBarLoading(false);
       updateAdvantageBar(null, { neutral: true, message: silent ? 'Awaiting evaluation' : 'Engine stopped' });
     }
@@ -4630,7 +4684,7 @@
         $('#best-move-button').prop('disabled', true);
         updateNavigationButtons();
         setAdvantageBarLoading(false);
-        setEvaluationText('Eval: --', 0.5);
+        setEvaluationText('Win chance --', 0.5);
         const statusMessage = shouldRetry ? 'Retrying…' : 'Engine error';
         updateAdvantageBar(null, { neutral: true, message: statusMessage });
         const errorForMessage = event && event.error instanceof Error
@@ -4970,11 +5024,11 @@
     }
 
     if (pieceAnalysis) {
-      setEvaluationText('Eval: --', 0.5);
+      setEvaluationText('Win chance --', 0.5);
     } else {
       const stored = getTimelineEntry(navigationIndex);
       if (!stored || typeof stored.value !== 'number') {
-        setEvaluationText('Eval: --', 0.5);
+        setEvaluationText('Win chance --', 0.5);
       }
     }
     setAdvantageBarLoading(true, { reset: !pieceAnalysis });
@@ -5488,7 +5542,7 @@
       clearRatings();
       latestAnalysisFen = null;
       currentBestMove = null;
-      setEvaluationText('Eval: --', 0.5);
+      setEvaluationText('Win chance --', 0.5);
       updateBestMoveDisplay();
       setAdvantageBarLoading(false);
       updateAdvantageBar(null, { neutral: true, message: 'Editing' });


### PR DESCRIPTION
## Summary
- redesign the advantage gauge so it sits inline with the turn status and exposes a compact percent readout
- style the gauge with a single thin bar, a 50% center marker, and an outline to improve contrast against the background
- adjust the evaluation logic to feed the new markup, update accessible labels, and synchronize the indicator’s state with the bar

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e2ea2c04188333aba1bcbae2321c3a