### PR TITLE
Make evaluation gauge accents yellow

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,8 +257,8 @@
     border-radius: 999px;
     overflow: hidden;
     background: rgba(10, 16, 28, 0.9);
-    border: 1px solid rgba(255, 255, 255, 0.18);
-    box-shadow: inset 0 0 0 1px rgba(7, 11, 20, 0.65);
+    border: 1px solid rgba(255, 214, 102, 0.85);
+    box-shadow: inset 0 0 0 1px rgba(120, 93, 14, 0.55);
     display: inline-block;
     min-width: 120px;
     transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
@@ -289,26 +289,26 @@
     bottom: 1px;
     width: 1px;
     left: calc(50% - 0.5px);
-    background: rgba(255, 255, 255, 0.65);
-    opacity: 0.8;
+    background: rgba(255, 214, 102, 0.95);
+    opacity: 0.9;
     pointer-events: none;
   }
 
   .advantage-bar.is-white-favored {
-    border-color: rgba(156, 195, 255, 0.6);
-    box-shadow: inset 0 0 0 1px rgba(120, 170, 255, 0.45);
+    border-color: rgba(255, 214, 102, 0.92);
+    box-shadow: inset 0 0 0 1px rgba(199, 151, 20, 0.5);
     background: rgba(18, 30, 52, 0.9);
   }
 
   .advantage-bar.is-black-favored {
-    border-color: rgba(178, 160, 255, 0.55);
-    box-shadow: inset 0 0 0 1px rgba(140, 120, 255, 0.42);
+    border-color: rgba(255, 214, 102, 0.9);
+    box-shadow: inset 0 0 0 1px rgba(185, 140, 16, 0.48);
     background: rgba(15, 16, 34, 0.92);
   }
 
   .advantage-bar.is-balanced {
-    border-color: rgba(255, 255, 255, 0.18);
-    box-shadow: inset 0 0 0 1px rgba(7, 11, 20, 0.65);
+    border-color: rgba(255, 214, 102, 0.85);
+    box-shadow: inset 0 0 0 1px rgba(120, 93, 14, 0.55);
   }
 
   .advantage-bar.is-loading::before {


### PR DESCRIPTION
## Summary
- recolor the evaluation gauge's midpoint indicator to a high-contrast yellow
- update the gauge border treatments across states to use the same yellow accent for better visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b3d4c3408333bacd9d4b6b8dbc34